### PR TITLE
Add solaris-amd64 to decred builds.

### DIFF
--- a/dcrinstallbuild.sh
+++ b/dcrinstallbuild.sh
@@ -21,7 +21,8 @@ MAINDIR=$PACKAGE-$TAG
 mkdir -p $MAINDIR
 cd $MAINDIR
 
-SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-386 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64"
+SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-386 darwin-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64"
+#BROKEN dragonfly-amd64 solaris-amd64
 
 # Use the first element of $GOPATH in the case where GOPATH is a list
 # (something that is totally allowed).

--- a/decredbuild.sh
+++ b/decredbuild.sh
@@ -21,7 +21,7 @@ MAINDIR=$PACKAGE-$TAG
 mkdir -p $MAINDIR
 cd $MAINDIR
 
-SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-386 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64"
+SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-386 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64 solaris-amd64"
 
 # Use the first element of $GOPATH in the case where GOPATH is a list
 # (something that is totally allowed).


### PR DESCRIPTION
Do not build dragonflybsd or solaris for dcrinstaller since both of
them fail to build.