### PR TITLE
Remove 32bit OSX/darwin builds

### DIFF
--- a/dcrinstallbuild.sh
+++ b/dcrinstallbuild.sh
@@ -22,7 +22,7 @@ MAINDIR=$PACKAGE-$TAG
 mkdir -p $MAINDIR
 cd $MAINDIR
 
-SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-386 darwin-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64"
+SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64"
 #BROKEN dragonfly-amd64 solaris-amd64
 
 # Use the first element of $GOPATH in the case where GOPATH is a list

--- a/decredbuild.sh
+++ b/decredbuild.sh
@@ -22,7 +22,7 @@ MAINDIR=$PACKAGE-$TAG
 mkdir -p $MAINDIR
 cd $MAINDIR
 
-SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-386 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64 solaris-amd64"
+SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64 solaris-amd64"
 
 # Use the first element of $GOPATH in the case where GOPATH is a list
 # (something that is totally allowed).


### PR DESCRIPTION
The last version of OSX to support 32bit processors was 10.6 Snow
Leopard from 2009.  No modern mac is likely to even be able to run
Snow Leopard.  For this reason we should not be building and providing
binaries for 32bit darwin.

Closes #49 